### PR TITLE
Atualizar configuração do cluster Kafka

### DIFF
--- a/kafka-cluster/kafka-cluster-persistent.yaml
+++ b/kafka-cluster/kafka-cluster-persistent.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kafka:
     version: 3.6.1
-    replicas: 3 #Quantidade de Brokers
+    replicas: 2 #Quantidade de Brokers
     listeners:
       - name: plain
         port: 9092
@@ -23,7 +23,8 @@ spec:
         configuration:
           bootstrap:
             annotations:
-              service.beta.kubernetes.io/oci-load-balancer-shape: "100Mbps"
+              # service.beta.kubernetes.io/oci-load-balancer-shape: "100Mbps"
+              oci.oraclecloud.com/load-balancer-type: "lb"
           brokers: []
     config:
       offsets.topic.replication.factor: 2
@@ -39,7 +40,7 @@ spec:
       volumes:
       - id: 0
         type: persistent-claim
-        size: 1Ti
+        size: 50Gi
         deleteClaim: false
     metricsConfig:
       type: jmxPrometheusExporter
@@ -62,7 +63,7 @@ spec:
     replicas: 1
     storage:
       type: persistent-claim
-      size: 100Gi
+      size: 50Gi
       deleteClaim: false
     metricsConfig:
       type: jmxPrometheusExporter

--- a/kafka-cluster/kafka-topic.yaml
+++ b/kafka-cluster/kafka-topic.yaml
@@ -6,7 +6,7 @@ metadata:
     strimzi.io/cluster: my-cluster
   namespace: kafka
 spec:
-  partitions: 3
+  partitions: 2
   replicas: 2
   config:
     retention.ms: 604800000

--- a/monitoring/grafana.yaml
+++ b/monitoring/grafana.yaml
@@ -53,6 +53,9 @@ metadata:
   name: grafana
   labels:
     app: strimzi
+  annotations:
+    oci.oraclecloud.com/load-balancer-type: "lb"
+    service.beta.kubernetes.io/oci-load-balancer-shape: "10Mbps"
 spec:
   ports:
   - name: grafana


### PR DESCRIPTION
Essa solicitação pull atualiza a configuração do cluster Kafka reduzindo o número de corretores para 2 e ajustando o tamanho dos volumes de armazenamento persistente. Ele também adiciona anotações para o tipo e shape do balanceador de carga.